### PR TITLE
Webp 파일 처리 로직

### DIFF
--- a/features/kerasEncoder.py
+++ b/features/kerasEncoder.py
@@ -14,13 +14,20 @@ from itertools import chain
 
 IMG_SIZE = 128
 
+#def convertImg(url):
+#     img = Image.open(urlopen(url))
+#     # save temporarily
+#     temp_byte = BytesIO()
+#     img.convert("RGB").save(temp_byte, "jpeg")
+#     img = Image.open(temp_byte)
+#     return np.array(img)
+
 def convertImg(url):
-    img = Image.open(urlopen(url)).convert("RGB")
-    # save temporarily
-    temp_byte = BytesIO()
-    img.save(temp_byte, "jpeg")
-    img = np.array(Image.open(temp_byte).convert("RGB"))
-    return img
+    img = Image.open(urlopen(url))
+    if img.is_animated:
+        img.seek(img.tell()+0) # 사용할 대표 이미지의 인덱스
+    img.show()
+    return np.array(img.convert("RGB"))
 
 def processImg(url):
     try:
@@ -61,5 +68,5 @@ def imgToVec(url):
 
 if __name__=="__main__":
     # sample image url(imageUrl)
-    vec = imgToVec('https://www.stylenanda.com/web/product/tiny/20200403/87c1d5150cc2239d128836f6ec19811f.webp')
+    vec = imgToVec('https://www.stylenanda.com/web/product/tiny/20200413/3342a9562d07513347ddc4ac7ed9fd7d.webp')
     print(vec)


### PR DESCRIPTION
큰 차이는 없긴 한데 PIL로 open한 파일의 경우 is_animated = True가 반환되어 여러 프레임에 접근할 수 있더라구요.

기본으로 맨 처음 프레임이 반환되기는 하지만 img.seek 코드를 추가해서 사용할 이미지를 특정하도록 설정했습니다.

```python
def convertImg(url):
    img = Image.open(urlopen(url))
    if img.is_animated:
        img.seek(img.tell()+0) # 사용할 대표 이미지의 인덱스
    img.show()
    return np.array(img.convert("RGB"))
```

중간에 img.show()는 주석처리를 하는게 나을 것 같네요. 아니면 팝업이 마구 뜰거라서.. ㅠㅠ